### PR TITLE
Don't display times for 00:00:00

### DIFF
--- a/display-carnie-gigs.php
+++ b/display-carnie-gigs.php
@@ -3,7 +3,7 @@
  * Plugin Name: Display Carnie Gigs
  * Plugin URI: https://github.com/OpenAirOrchestra/display-carnie-gigs
  *  Description: Display Gigs from carnie-gigs plugin on a second, public webstie.
- * Version: 1.0
+ * Version: 1.1
  * Author: Open Air Orchestra Webmonkey
  * Author URI: mailto://oaowebmonkey@gmail.com
  * License: GPL2

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.thecarnivalband.com/
 Tags: gigs, calendar
 Requires at least: 5.3.1
 Tested up to: 6.1
-Stable tag: 1.0
+Stable tag: 1.1
 
 Display Gig Calendar on a second website for The Carnival Band.
 
@@ -43,3 +43,6 @@ The shortcode [display-carniegigs] is used to display gigs.  Here are some examp
 
 = 1.0 =
 * Bug fix
+
+= 1.1 =
+Don't display time for 00:00:00

--- a/views/gig.php
+++ b/views/gig.php
@@ -170,13 +170,13 @@ class displayCarnieGigView {
 			}
 			$output .= "<p class='times'>";
 
-			if (strlen($gig['eventstart']) > 0)
+			if (strlen($gig['eventstart']) > 0 && $gig['eventstart'] != '00:00:00')
 			{
 				$output .= "Event start: ";
 				$output .= date('g:ia', strtotime($gig['eventstart']));
 				$output .= ". ";
 			}
-			if (strlen($gig['performancestart']) > 0)
+			if (strlen($gig['performancestart']) > 0 && $gig['performancestart'] != '00:00:00')
 			{
 				$output .= "Performance start: ";
 				$output .= date('g:ia', strtotime($gig['performancestart']));


### PR DESCRIPTION
The gig mirror database, as it stands, has 00:00:00 for unspecified dates.  Don't show that.